### PR TITLE
Update epistemic-disadvantage.md

### DIFF
--- a/docs/concepts/epistemic-disadvantage.md
+++ b/docs/concepts/epistemic-disadvantage.md
@@ -10,7 +10,7 @@
 
 ## 🔗 Relations
 
-- **similar to**: [epistemic injustice](./epistemic-injustice.md)
+- **coextensive with**: [epistemic injustice](./epistemic-injustice.md)
 - **distinct from**: [epistemic injustice](./epistemic-injustice.md)
 
 ## 📚 References


### PR DESCRIPTION
Requesting to use 'coextensive with' as relation type between epistemic disadvantage and epistemic injustice. However, if you would prefer to use 'similar to' and 'distinct from' to keep things simple, that's ok too! I will just then remove 'coextensive with' from the relation types. Do let me know your opinions.